### PR TITLE
fix(landing): render visible hero; align login dropdown; base styles

### DIFF
--- a/Homescreen.php
+++ b/Homescreen.php
@@ -1,159 +1,221 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>I-Tracks</title>
-  <link rel="stylesheet" href="style/hmmenu.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>I‑Tracks | Capstone Tracker</title>
+
+  <!-- Bootstrap 5 -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Font Awesome (for icons) -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <!-- Keep existing styles if needed elsewhere -->
+  <link rel="stylesheet" href="style/hmmenu.css" />
 
   <style>
-    .trimexlogo a {
-      text-decoration: none;
-      color: black;
-      padding: 6px 12px;
-      border-radius: 4px;
-      transition: background-color 0.2s ease;
+    :root { --accent:#e11d48; }
+    .hero-bg {
+      background:
+        radial-gradient(40rem 40rem at 110% -10%, rgba(225,29,72,.06), transparent 40%),
+        radial-gradient(36rem 36rem at -10% -10%, rgba(14,165,233,.06), transparent 40%);
     }
-
-    /* Dropdown login box */
-    .login-dropdown {
-      display: none;
-      position: absolute;
-      right: 30px;
-      top: 50px;
-      transform: translateX(-90px);
-      background-color: white;
-      padding: 20px;
-      border: 1px solid #ccc;
-      border-radius: 10px;
-      width: 250px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-      z-index: 100;
-    }
-
-    .login-dropdown input {
-      width: 90%;
-      padding: 8px;
-      margin: 6px 0;
-      border: 1px solid #ccc;
-      border-radius: 5px;
-      font-size: 14px;
-    }
-
-    .login-dropdown button[type="submit"] {
-      width: 100%;
-      padding: 8px;
-      border: none;
-      background-color: red;
-      color: white;
-      border-radius: 5px;
-      cursor: pointer;
-      font-size: 15px;
-    }
-
-    .login-dropdown button[type="submit"]:hover {
-      background-color: darkred;
-    }
-
-    .auth-links {
-      position: relative;
-    }
-
-    /* Password wrapper (no Bootstrap) */
-    .password-wrappers {
-      position: relative;
-    }
-
-    .password-wrappers input {
-      width: 80%;
-      padding-right: 35px; /* space for the icon */
-    }
-
-    .toggle-password-btn {
-      position: absolute;
-      right: 8px;
-      top: 50%;
-      transform: translateY(-50%);
-      background: none;
-      border: none;
-      color: #777;
-      cursor: pointer;
-      font-size: 16px;
-      padding: 0;
-    }
-
-    .toggle-password-btn:hover {
-      color: #000;
-    }
-
-    .auth-links a {
-      text-decoration: none;
-      color: black;
-      margin-left: 15px;
-      font-weight: bold;
-    }
-
-    .auth-links a:hover {
-      color: red;
-    }
+    .brand-accent { color: var(--accent) !important; }
+    .btn-accent { background: var(--accent); color:#fff; }
+    .btn-accent:hover { filter:brightness(.95); color:#fff; }
   </style>
 </head>
-<body>
+<body class="bg-white text-dark">
+  <!-- Navbar -->
+  <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom sticky-top">
+    <div class="container">
+      <a class="navbar-brand fw-bold" href="Homescreen.php">
+        <i class="fa-solid fa-layer-group me-2 brand-accent"></i>CAPSTONE TRACKER
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
+          <li class="nav-item"><a class="nav-link" href="#objectives">Objectives</a></li>
+          <li class="nav-item me-lg-2 mt-2 mt-lg-0">
+            <a class="btn btn-outline-secondary" href="Signup.php">Sign up</a>
+          </li>
+          <li class="nav-item mt-2 mt-lg-0">
+            <button class="btn btn-accent" data-bs-toggle="modal" data-bs-target="#loginModal">Log in</button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
 
-<div class="navbar">
-  <div class="trimexlogo">
-    <a href="Homescreen.php">CAPSTONE TRACKER</a>
-  </div>
-  <div class="auth-links">
-    <a href="#" id="loginBtn" class="login">Log in</a>
-    <a href="Signup.php" class="signup">Sign up</a>
-
-    <!-- Dropdown Login -->
-    <div id="loginBox" class="login-dropdown">
-      <form action="api/login_process.php" method="POST">
-        <input type="text" name="username" placeholder="Username" required>
-
-        <div class="password-wrappers">
-          <input type="password" id="password" name="password" placeholder="Password" required />
-          <button type="button" id="togglePassword" class="toggle-password-btn">
-            <i class="fa-solid fa-eye"></i>
-          </button>
+  <!-- Hero -->
+  <header class="py-5 hero-bg">
+    <div class="container py-4">
+      <div class="row align-items-center g-4">
+        <div class="col-lg-7">
+          <h1 class="display-5 fw-bold mb-3">I‑Tracks</h1>
+          <p class="lead text-secondary mb-4">Interactive platform for tracking capstone proposals, milestones, reviews, and final outputs across the College of Computer Studies.</p>
+          <div class="d-flex gap-2">
+            <button class="btn btn-accent btn-lg" data-bs-toggle="modal" data-bs-target="#loginModal">
+              <i class="fa-solid fa-right-to-bracket me-2"></i>Log in
+            </button>
+            <a class="btn btn-outline-secondary btn-lg" href="Signup.php">
+              <i class="fa-solid fa-user-plus me-2"></i>Create account
+            </a>
+          </div>
         </div>
-          <button type="submit">Login</button>
+        <div class="col-lg-5">
+          <div class="card shadow-sm border-0">
+            <div class="card-body p-4">
+              <h5 class="card-title mb-3">Capstone Project Platform</h5>
+              <p class="mb-2">A capstone project by</p>
+              <ul class="list-unstyled small mb-0">
+                <li class="mb-1"><i class="fa-regular fa-user me-2 text-secondary"></i>Kyle Austin Nagares</li>
+                <li class="mb-1"><i class="fa-regular fa-user me-2 text-secondary"></i>John Harly Pinugu</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
 
-     
-      </form>
+  <!-- About / Context -->
+  <section id="about" class="py-5">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <h2 class="h3 fw-bold mb-3">Project Context</h2>
+          <p class="text-secondary mb-4">
+            The main goal of the College of Computer Studies’ Interactive Digital Platform for Tracking Capstone Projects is to make it easier for students, teachers, and staff to keep track of capstone projects and how far along each one is. More specifically, the platform aims to create one system where everyone involved can easily manage and follow each project’s progress. It also helps make the process of submitting project ideas and final outputs more organized and smoother, reducing confusion or delays. Lastly, it gives faculty advisers better tools to monitor student progress, provide feedback, and approve work, making it easier for them to guide students through their capstone journey.
+          </p>
+
+          <div class="row g-3">
+            <div class="col-md-4">
+              <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body">
+                  <div class="d-flex align-items-center mb-2">
+                    <i class="fa-solid fa-diagram-project me-2 text-primary"></i>
+                    <h3 class="h6 mb-0">Centralized Tracking</h3>
+                  </div>
+                  <p class="small text-secondary mb-0">Organize projects, proposals, milestones, and final outputs in one place.</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body">
+                  <div class="d-flex align-items-center mb-2">
+                    <i class="fa-solid fa-paper-plane me-2 text-success"></i>
+                    <h3 class="h6 mb-0">Streamlined Submissions</h3>
+                  </div>
+                  <p class="small text-secondary mb-0">Reduce delays with a clear flow for idea proposals and approvals.</p>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body">
+                  <div class="d-flex align-items-center mb-2">
+                    <i class="fa-solid fa-user-check me-2 text-warning"></i>
+                    <h3 class="h6 mb-0">Adviser Tools</h3>
+                  </div>
+                  <p class="small text-secondary mb-0">Monitor progress, provide feedback, and approve work efficiently.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Objectives -->
+  <section id="objectives" class="py-5 bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="row g-4 align-items-stretch">
+            <div class="col-md-5">
+              <div class="p-4 bg-white border rounded-3 h-100">
+                <h2 class="h4 fw-bold mb-2">General Objective</h2>
+                <p class="mb-0 text-secondary">Create an uncomplicated platform enabling students, staff, and teachers to track capstone projects for each project.</p>
+              </div>
+            </div>
+            <div class="col-md-7">
+              <div class="p-4 bg-white border rounded-3 h-100">
+                <h3 class="h5 fw-bold mb-3">Specific Objectives</h3>
+                <ul class="mb-0 text-secondary">
+                  <li class="mb-2">Develop a centralized system that allows students and faculty to efficiently organize, track, and manage capstone projects.</li>
+                  <li class="mb-2">Provide a systematic procedure for project ideas and final submissions to improve the submission and approval process.</li>
+                  <li class="mb-2">Create better monitoring and collaboration through simpler tools for advisers to analyze, advise on, and approve capstone work.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="py-4 border-top bg-white">
+    <div class="container d-flex flex-wrap justify-content-between align-items-center">
+      <span class="text-secondary small">© <span id="y"></span> I‑Tracks • College of Computer Studies</span>
+    </div>
+  </footer>
+
+  <!-- Login Modal -->
+  <div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Sign in</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <form action="api/login_process.php" method="POST">
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="login-username" class="form-label">Username</label>
+              <input type="text" id="login-username" name="username" class="form-control" autocomplete="username" required />
+            </div>
+            <div class="mb-2">
+              <label for="login-password" class="form-label">Password</label>
+              <div class="input-group">
+                <input type="password" id="login-password" name="password" class="form-control" autocomplete="current-password" required />
+                <button class="btn btn-outline-secondary" type="button" id="togglePassword" aria-label="Toggle password visibility">
+                  <i class="fa-solid fa-eye"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-accent">Login</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
-</div>
 
-<script>
-  // Toggle dropdown visibility
-  const loginBtn = document.getElementById('loginBtn');
-  const loginBox = document.getElementById('loginBox');
-
-  loginBtn.addEventListener('click', function(e) {
-    e.preventDefault();
-    loginBox.style.display = loginBox.style.display === 'block' ? 'none' : 'block';
-  });
-
-  window.addEventListener('click', function(e) {
-    if (!loginBox.contains(e.target) && e.target !== loginBtn) {
-      loginBox.style.display = 'none';
+  <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    // year in footer
+    document.getElementById('y').textContent = new Date().getFullYear();
+    // Password visibility toggle
+    const togglePasswordBtn = document.getElementById('togglePassword');
+    const passwordInput = document.getElementById('login-password');
+    if (togglePasswordBtn && passwordInput) {
+      togglePasswordBtn.addEventListener('click', function () {
+        const isPassword = passwordInput.getAttribute('type') === 'password';
+        passwordInput.setAttribute('type', isPassword ? 'text' : 'password');
+        const icon = this.querySelector('i');
+        icon.classList.toggle('fa-eye');
+        icon.classList.toggle('fa-eye-slash');
+      });
     }
-  });
-
-  // Password visibility toggle
-  document.getElementById('togglePassword').addEventListener('click', function() {
-    const passwordInput = document.getElementById('password');
-    const icon = this.querySelector('i');
-    const isPassword = passwordInput.getAttribute('type') === 'password';
-    passwordInput.setAttribute('type', isPassword ? 'text' : 'password');
-    icon.classList.toggle('fa-eye');
-    icon.classList.toggle('fa-eye-slash');
-  });
-</script>
-
+  </script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# Itrack
-CAPSTONE 1
+# Itrack – Capstone Tracker
+
+Interactive platform for the College of Computer Studies to organize, track, and manage capstone projects from proposal to final submission. The landing page now uses Bootstrap 5 for a clean, responsive experience.
+
+## Quick Start
+
+- Requirements: XAMPP/LAMP/WAMP (Apache + PHP + MySQL)
+- Clone/copy this repo into your web root (e.g., `htdocs/Itrack`).
+- Import the database: `sql/capstone_tracker.sql` (or `capstone_tracker.sql` in the project root).
+- Configure credentials in `database.php`.
+- Start Apache and MySQL, then open `http://localhost/Itrack/Homescreen.php`.
+
+## Key Pages
+
+- `Homescreen.php`: Bootstrap 5 landing page with About and Objectives
+- `Signup.php`: Registration page
+- `dashboard.php`: App dashboard after login
+
+## Project Context
+
+The main goal of the College of Computer Studies’ Interactive Digital Platform for Tracking Capstone Projects is to make it easier for students, teachers, and staff to keep track of capstone projects and how far along each one is. More specifically, the platform aims to create one system where everyone involved can easily manage and follow each project’s progress. It also helps make the process of submitting project ideas and final outputs more organized and smoother, reducing confusion or delays. Lastly, it gives faculty advisers better tools to monitor student progress, provide feedback, and approve work, making it easier for them to guide students through their capstone journey.
+
+### General Objective
+
+Create an uncomplicated platform enabling students, staff, and teachers to track capstone projects for each project.
+
+### Specific Objectives
+
+1. Develop a centralized system that allows students and faculty to efficiently organize, track, and manage capstone projects.
+2. Provide a systematic procedure for project ideas and final submissions to improve the submission and approval process.
+3. Create better monitoring and collaboration through simpler tools for advisers to analyze, advise on, and approve capstone work.
+
+## Tech Notes
+
+- UI: Bootstrap 5 (CDN) + Font Awesome
+- Backend: PHP + MySQL (see `database.php` and `api/` endpoints)
+- Optional: Webpack bundling is available for `/src` assets (see `package.json` and `webpack.config.js`). T
+## Authors
+
+- Kyle Austin Nagares
+- John Harly Pinugu


### PR DESCRIPTION
## What
Make the landing page visible and fix the misaligned login dropdown.

## Why
`Homescreen.php` appeared “blank” (no visible section height) and the login dropdown could render off-screen due to a hard `transform` offset.

## How
- Add a minimal hero section with `min-height: calc(100vh - 64px)` to ensure visible content.
- Replace `transform: translateX(-90px)` with right-anchored dropdown (`right: 0; top: 48px;`) and toggle via `.open` class.
- Improve JS: outside-click + Escape to close; support secondary “Log in” button.

## Screenshots
**Before**
<img width="1361" height="648" alt="landingpage" src="https://github.com/user-attachments/assets/4d7e4d12-d451-44c4-bb1e-4e9f95e17c37" />


**After**
<img width="1364" height="729" alt="afterlandingpage" src="https://github.com/user-attachments/assets/8ef25d1a-9081-4e9b-acdc-bc4e33db84a5" />


## Verification
- Load `Homescreen.php` → hero visible.
- Click **Log in** (navbar & hero) → dropdown appears, fully on-screen.
- Click outside / press **Esc** → dropdown closes.
- No console errors; `style/hmmenu.css` returns 200.

## Scope
UI only (`Homescreen.php`, styles, small JS). No backend/API changes.

## Risks
Low; layout/CSS-only adjustments.

Closes #2
