### PR TITLE
feat(layout): implement shared layout and unify public pages (Home/Signup)

### DIFF
--- a/Signup.php
+++ b/Signup.php
@@ -1,287 +1,67 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>I-Tracks</title>
-<!-- Load Bootstrap FIRST -->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+<?php
+  $page_title = 'I‑Tracks | Sign up';
+  $is_home = false;
+  $hero_title = 'Create Account';
+  $hero_subtitle = 'Join to track and manage capstone projects';
+  include 'includes/header.php';
+  include 'includes/navbar.php';
+  include 'includes/hero.php';
+?>
 
+<section class="py-5">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-8 col-lg-6">
+        <div class="card shadow-sm border-0">
+          <div class="card-body p-4">
+            <h2 class="h4 fw-bold mb-4">Register</h2>
+            <form action="api/Register_process.php" method="POST">
+              <div class="mb-3">
+                <label for="first_name" class="form-label">First Name</label>
+                <div class="input-group">
+                  <span class="input-group-text"><i class="fa-regular fa-user"></i></span>
+                  <input type="text" id="first_name" name="first_name" class="form-control" placeholder="First Name" required />
+                </div>
+              </div>
 
+              <div class="mb-3">
+                <label for="last_name" class="form-label">Last Name</label>
+                <div class="input-group">
+                  <span class="input-group-text"><i class="fa-regular fa-user"></i></span>
+                  <input type="text" id="last_name" name="last_name" class="form-control" placeholder="Last Name" required />
+                </div>
+              </div>
 
-  <style>
-        
-        .register-box {
-            background: #ffffff;
-            padding: 80px 50px;
-            width: 400px;
-            text-align: center;
-            margin: 0 auto; /* horizontally center */
-            
-           
-        }
+              <div class="mb-3">
+                <label for="username" class="form-label">Username</label>
+                <div class="input-group">
+                  <span class="input-group-text"><i class="fa-regular fa-envelope"></i></span>
+                  <input type="text" id="username" name="username" class="form-control" placeholder="Username" required />
+                </div>
+              </div>
 
-        .register-box h2 {
-            margin-bottom: 20px;
-            color: #333;
-        }
+              <div class="mb-3">
+                <label for="signup-password" class="form-label">Password</label>
+                <div class="input-group">
+                  <span class="input-group-text"><i class="fa-solid fa-lock"></i></span>
+                  <input type="password" id="signup-password" name="password" class="form-control" placeholder="Password" required />
+                  <button type="button" id="signup-togglePassword" class="btn btn-outline-secondary" aria-label="Toggle password visibility">
+                    <i class="fa-solid fa-eye"></i>
+                  </button>
+                </div>
+              </div>
 
-        .register-box input,
-        .register-box select {
-            width: 100%;
-            padding: 20px;
-            margin-bottom: 20px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-   .input-group {
-      margin-bottom: 10px;
-    }
-
-    .form-control {
-      border-radius: 5px !important;
-    }
-        .register-box button {
-            width: 100%;
-            padding: 10px;
-            background: #007bff;
-            color: #fff;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-        }
-
-        .register-box button:hover {
-            background: #0056b3;
-        }
-
-        .register-box a {
-            display: block;
-            margin-top: 15px;
-            
-            color: #007bff;
-            text-decoration: none;
-        }
-
-        .register-box a:hover {
-            text-decoration: underline;
-        }
-        
-                .password-wrapper {
-                position: relative;
-                }
-
-                .password-wrapper input {
-                width: 100%;
-                padding-right: 10px; /* leave space for the button */
-                }
-
-                .password-wrapper button {
-                    width: 80px;
-                    height: 30px;
-                position: absolute;
-                right: -80px;
-                top: 13%;
-                transform: translateY(-10%);
-                background: #007bff;
-                color: #fff;
-                border: none;
-                border-radius: 10px;
-                cursor: pointer;
-                }
-        .trimexlogo a
-         {
-            text-decoration: none;
-            color: black;
-           
-            padding: 6px 12px;
-            border-radius: 4px;
-            transition: background-color 0.2s ease;
-            }
-/* === Scoped Login Dropdown === */
-    .navbar .auth-links {
-      position: relative;
-    }
-
-    .navbar .auth-links .login-dropdown {
-   display: none;
-      position: absolute;
-      right: 30px;
-      top: 50px;
-      transform: translateX(-90px);
-      background-color: white;
-      padding: 20px;
-      border: 1px solid #ccc;
-      border-radius: 10px;
-      width: 250px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-      z-index: 100;
-    }
-
-    .navbar .auth-links .login-dropdown input {
-     width: 90%;
-      padding: 8px;
-      margin: 6px 0;
-      border: 1px solid #ccc;
-      border-radius: 5px;
-      font-size: 14px;
-    }
-
-    .navbar .auth-links .login-dropdown button[type="submit"] {
-      width: 100%;
-      padding: 8px;
-      border: none;
-      background-color: red;
-      color: white;
-      border-radius: 5px;
-      cursor: pointer;
-      font-size: 15px;
-    }
-
-    .navbar .auth-links .login-dropdown button[type="submit"]:hover {
-      background-color: darkred;
-    }
-
-    /* === Scoped Password Toggle === */
-    .navbar .auth-links .login-dropdown .password-wrapper {
-      position: relative;
-    }
-
-    .navbar .auth-links .login-dropdown .password-wrapper input {
-      width: 100%;
-      padding-right: 35px; /* space for eye icon */
-    }
-
-    .navbar .auth-links .login-dropdown .toggle-password-btn {
-      position: absolute;
-      right: 8px;
-      top: 50%;
-      transform: translateY(-50%);
-      background: none;
-      border: none;
-      color: #777;
-      cursor: pointer;
-      font-size: 16px;
-      padding: 0;
-    }
-
-    .navbar .auth-links .login-dropdown .toggle-password-btn:hover {
-      color: #000;
-    }
-     .navbar .auth-links .password-wrappers {
-      position: relative;
-    }
-
-     .navbar .auth-links .password-wrappers input {
-      width: 80%;
-      padding-right: 35px; /* space for the icon */
-    }
-
-     .navbar .auth-links .toggle-password-btn {
-      position: absolute;
-      right: 8px;
-      top: 50%;
-      transform: translateY(-50%);
-      background: none;
-      border: none;
-      color: #777;
-      cursor: pointer;
-      font-size: 16px;
-      padding: 0;
-    }
-
-     .navbar .auth-links .toggle-password-btn:hover {
-      color: #000;
-    }
-
-
-
-    </style>
-   <!-- Load YOUR styles AFTER -->
-<link rel="stylesheet" href="style/hmmenu.css">
-</head>
-<body>
-   <div class="navbar">
-  <div class="trimexlogo">
-    <a href="Homescreen.php">CAPSTONE TRACKER</a>
-  </div>
-  <div class="auth-links">
-    <a href="#" id="loginBtn" class="login">Login</a>
-    <a href="Signup.php" class="signup">Sign up</a>
-
-    <!-- Dropdown Login -->
-    <div id="loginBox" class="login-dropdown">
-      <form action="api/login_process.php" method="POST">
-        <input type="text" name="username" placeholder="Username" required>
-
-        <div class="password-wrappers">
-          <input type="password" id="password1" name="password" placeholder="Password" required />
-          <button type="button" id="togglePassword1" class="toggle-password-btn">
-            <i class="fa-solid fa-eye"></i>
-          </button>
+              <div class="d-grid">
+                <button type="submit" class="btn btn-accent">Register</button>
+              </div>
+            </form>
+          </div>
         </div>
-        <button type="submit">Login</button>
-        
-      </form>
+      </div>
     </div>
   </div>
-</div>
-  <div class="register-box">
-    <h2>Register</h2>
+  
+</section>
 
-    <form action="api/Register_process.php" method="POST">
-      <div class="input-group">
-        <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
-        <input type="text" name="first_name" class="form-control" placeholder="First Name" required />
-      </div>
+<?php include 'includes/footer.php'; ?>
 
-      <div class="input-group">
-        <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
-        <input type="text" name="last_name" class="form-control" placeholder="Last Name" required />
-      </div>
-
-      <div class="input-group">
-        <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
-        <input type="text" name="username" class="form-control" placeholder="Username" required />
-      </div>
-
-     <div class="input-group password-wrapper">
-      <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
-      <input type="password" id="password2" name="password" class="form-control" placeholder="Password" required />
-      <button type="button" id="togglePassword2" class="toggle-password-btn">
-        <i class="glyphicon glyphicon-eye-open"></i>
-  </button>
-</div>
-
-      <button type="submit">Register</button>
-    </form>
-  </div>
-
-<script src="src/toggle-password.js"></script>
-<script>
-  // Toggle dropdown visibility
-  const loginBtn = document.getElementById('loginBtn');
-  const loginBox = document.getElementById('loginBox');
-
-  loginBtn.addEventListener('click', function(e) {
-    e.preventDefault();
-    loginBox.style.display = loginBox.style.display === 'block' ? 'none' : 'block';
-  });
-
-  window.addEventListener('click', function(e) {
-    if (!loginBox.contains(e.target) && e.target !== loginBtn) {
-      loginBox.style.display = 'none';
-    }
-  });
-    document.getElementById('togglePassword1').addEventListener('click', function() {
-    const passwordInput = document.getElementById('password1');
-    const icon = this.querySelector('i');
-    const isPassword = passwordInput.getAttribute('type') === 'password';
-    passwordInput.setAttribute('type', isPassword ? 'text' : 'password');
-    icon.classList.toggle('fa-eye');
-    icon.classList.toggle('fa-eye-slash');
-  });
-</script>
-</body>
-</html>

--- a/___tmp_home_sections__.txt
+++ b/___tmp_home_sections__.txt
@@ -1,12 +1,3 @@
-<?php
-  $page_title = 'I‑Tracks | Capstone Tracker';
-  $is_home = true;
-  $hero_page = 'home';
-  include 'includes/header.php';
-  include 'includes/navbar.php';
-  include 'includes/hero.php';
-?>
-
   <!-- About / Context -->
   <section id="about" class="py-5">
     <div class="container">
@@ -84,6 +75,4 @@
       </div>
     </div>
   </section>
-
-<?php include 'includes/footer.php'; ?>
 

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,86 @@
+  <!-- Footer -->
+  <footer class="py-4 border-top bg-white mt-auto">
+    <div class="container d-flex flex-wrap justify-content-between align-items-center">
+      <span class="text-secondary small">© <span id="y"></span> I‑Tracks — College of Computer Studies</span>
+    </div>
+  </footer>
+
+  <!-- Login Modal (shared across public pages) -->
+  <div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Sign in</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <form action="api/login_process.php" method="POST">
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="login-username" class="form-label">Username</label>
+              <input type="text" id="login-username" name="username" class="form-control" autocomplete="username" required />
+            </div>
+            <div class="mb-2">
+              <label for="login-password" class="form-label">Password</label>
+              <div class="input-group">
+                <input type="password" id="login-password" name="password" class="form-control" autocomplete="current-password" required />
+                <button class="btn btn-outline-secondary" type="button" id="togglePassword" aria-label="Toggle password visibility">
+                  <i class="fa-solid fa-eye"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-accent">Login</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    // year in footer
+    (function(){
+      var yearEl = document.getElementById('y');
+      if (yearEl) yearEl.textContent = new Date().getFullYear();
+    })();
+
+    // Password visibility toggle for login modal
+    (function(){
+      var togglePasswordBtn = document.getElementById('togglePassword');
+      var passwordInput = document.getElementById('login-password');
+      if (togglePasswordBtn && passwordInput) {
+        togglePasswordBtn.addEventListener('click', function () {
+          var isPassword = passwordInput.getAttribute('type') === 'password';
+          passwordInput.setAttribute('type', isPassword ? 'text' : 'password');
+          var icon = this.querySelector('i');
+          if (icon) {
+            icon.classList.toggle('fa-eye');
+            icon.classList.toggle('fa-eye-slash');
+          }
+        });
+      }
+    })();
+
+    // Optional: password toggle for signup page if present
+    (function(){
+      var signupToggle = document.getElementById('signup-togglePassword');
+      var signupPass = document.getElementById('signup-password');
+      if (signupToggle && signupPass) {
+        signupToggle.addEventListener('click', function () {
+          var isPassword = signupPass.getAttribute('type') === 'password';
+          signupPass.setAttribute('type', isPassword ? 'text' : 'password');
+          var icon = this.querySelector('i');
+          if (icon) {
+            icon.classList.toggle('fa-eye');
+            icon.classList.toggle('fa-eye-slash');
+          }
+        });
+      }
+    })();
+  </script>
+</body>
+</html>
+

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,61 @@
+<?php
+// Shared header: doctype, head, CSS, and opening body
+// Usage: set $page_title (optional) before including
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title><?php echo isset($page_title) ? htmlspecialchars($page_title) : 'CAPSTONE TRACKER'; ?></title>
+
+  <!-- Bootstrap 5 -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Font Awesome (for icons) -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <!-- Site styles -->
+  <link rel="stylesheet" href="style/hmmenu.css" />
+
+  <style>
+    :root { --accent:#e11d48; }
+    html, body { max-width: 100%; overflow-x: hidden; }
+    /* Normalize navbar styles across pages (override hmmenu.css where needed) */
+    .navbar {
+      padding: .5rem 1rem;
+      background-color: #fff;
+      border-bottom: 1px solid #dee2e6;
+      font-size: 1rem;
+    }
+    .navbar .navbar-toggler {
+      margin-left: auto;
+      min-width: 44px;
+      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .navbar .navbar-brand {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
+    @media (max-width: 430px) {
+      .navbar { padding: .5rem .75rem; }
+      .navbar .navbar-brand { font-size: 1rem; }
+      .navbar .navbar-collapse { padding-top: .25rem; }
+      .navbar .nav-link { padding: .75rem .5rem; }
+    }
+    /* Shared helpers */
+    .hero-bg {
+      background:
+        radial-gradient(40rem 40rem at 110% -10%, rgba(225,29,72,.06), transparent 40%),
+        radial-gradient(36rem 36rem at -10% -10%, rgba(14,165,233,.06), transparent 40%);
+    }
+    .brand-accent { color: var(--accent) !important; }
+    .btn-accent { background: var(--accent); color:#fff; }
+    .btn-accent:hover { filter:brightness(.95); color:#fff; }
+  </style>
+</head>
+<body class="bg-white text-dark">
+

--- a/includes/hero.php
+++ b/includes/hero.php
@@ -1,0 +1,52 @@
+<?php
+// Shared hero section
+// Usage:
+//   - Home page: set $hero_page = 'home'
+//   - Other pages: set $hero_title = 'Page Title'
+?>
+<?php if (isset($hero_page) && $hero_page === 'home'): ?>
+  <header class="py-5 hero-bg">
+    <div class="container py-4">
+      <div class="row align-items-center g-4">
+        <div class="col-lg-7">
+          <h1 class="display-5 fw-bold mb-3">I‑Tracks</h1>
+          <p class="lead text-secondary mb-4">Interactive platform for tracking capstone proposals, milestones, reviews, and final outputs across the College of Computer Studies.</p>
+          <div class="d-flex gap-2">
+            <button class="btn btn-accent btn-lg" data-bs-toggle="modal" data-bs-target="#loginModal">
+              <i class="fa-solid fa-right-to-bracket me-2"></i>Log in
+            </button>
+            <a class="btn btn-outline-secondary btn-lg" href="Signup.php">
+              <i class="fa-solid fa-user-plus me-2"></i>Create account
+            </a>
+          </div>
+        </div>
+        <div class="col-lg-5">
+          <div class="card shadow-sm border-0">
+            <div class="card-body p-4">
+              <h5 class="card-title mb-3">Capstone Project Platform</h5>
+              <p class="mb-2">A capstone project by</p>
+              <ul class="list-unstyled small mb-0">
+                <li class="mb-1"><i class="fa-regular fa-user me-2 text-secondary"></i>Kyle Austin Nagares</li>
+                <li class="mb-1"><i class="fa-regular fa-user me-2 text-secondary"></i>John Harly Pinugu</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+<?php elseif (isset($hero_title)): ?>
+  <header class="py-5 hero-bg">
+    <div class="container py-4">
+      <div class="row justify-content-center">
+        <div class="col-lg-8 text-center">
+          <h1 class="display-6 fw-bold mb-2"><?php echo htmlspecialchars($hero_title); ?></h1>
+          <?php if (!empty($hero_subtitle)): ?>
+            <p class="lead text-secondary mb-0"><?php echo htmlspecialchars($hero_subtitle); ?></p>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+  </header>
+<?php endif; ?>
+

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -1,0 +1,31 @@
+<?php
+// Shared Bootstrap navbar
+// Optional: set $is_home = true on home page to keep in-page anchors
+?>
+<nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom sticky-top">
+  <div class="container">
+    <a class="navbar-brand fw-bold" href="Homescreen.php">
+      <i class="fa-solid fa-layer-group me-2 brand-accent"></i>CAPSTONE TRACKER
+    </a>
+    <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainNav">
+      <ul class="navbar-nav ms-auto align-items-lg-center">
+        <?php
+          $aboutHref = (isset($is_home) && $is_home) ? '#about' : 'Homescreen.php#about';
+          $objHref = (isset($is_home) && $is_home) ? '#objectives' : 'Homescreen.php#objectives';
+        ?>
+        <li class="nav-item"><a class="nav-link" href="<?php echo $aboutHref; ?>">About</a></li>
+        <li class="nav-item"><a class="nav-link" href="<?php echo $objHref; ?>">Objectives</a></li>
+        <li class="nav-item me-lg-2 mt-2 mt-lg-0">
+          <a class="btn btn-outline-secondary" href="Signup.php">Sign up</a>
+        </li>
+        <li class="nav-item mt-2 mt-lg-0">
+          <button class="btn btn-accent" data-bs-toggle="modal" data-bs-target="#loginModal">Log in</button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
+


### PR DESCRIPTION
## What
Implemented a shared layout and unified the public pages so the landing, Sign up (and later Login) use the same header/hero/footer and scripts.

## Why
Public pages rendered inconsistent headers/footers and mixed Bootstrap versions, causing visual jumps and broken anchors when navigating from non-home pages.

## How
- **Shared partials**
  - `includes/header.php` — Doctype, `<head>`, Bootstrap 5, Font Awesome, global styles; opens `<body>`.
  - `includes/navbar.php` — Single Bootstrap navbar; uses `$is_home` to switch internal anchors (`#about`, `#objectives`) vs `Homescreen.php#…`.
  - `includes/hero.php` — Reusable hero.
    - Home: full landing hero via `$hero_page = 'home'`
    - Others: simple hero if `$hero_title` is set
  - `includes/footer.php` — Global footer, shared Login modal, Bootstrap JS bundle, current year, password toggle script.
- **Refactors**
  - `Homescreen.php` — Sets `$page_title`, `$is_home = true`, `$hero_page = 'home'`; includes shared partials; preserves About/Objectives sections.
  - `Signup.php` — Sets `$page_title`, `$is_home = false`, `$hero_title = 'Create Account'`; includes shared partials; updated to Bootstrap 5 with show/hide password.

## Behavior
- Consistent header/nav/hero/footer across Home and Sign up.
- Navbar links **About** / **Objectives** stay valid on non-home pages.
- **Login** opens a shared modal on both pages.
- Unified on **Bootstrap 5** (Signup upgraded from BS3).

## Screenshots
**Before:** 
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/54c7ef64-dd7d-4987-a807-735d938827d8" />

**After:** 
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6d990a46-2b90-4113-86f5-cfd85fbfcdce" />


## Verification
- Navigate between `Homescreen.php` ↔ `Signup.php`: header/hero/footer remain consistent.
- Anchors:
  - On Home: `#about` and `#objectives` scroll correctly.
  - On other pages: links point to `Homescreen.php#about|#objectives`.
- Login modal opens on both pages.
- Mobile (320/360/375/390/414/430px): navbar collapses/expands; no overlap; tap targets ≥ 44×44px.
- No console errors; Bootstrap **JS bundle** loads once.

## Risks
Low — markup/structure & includes. No backend logic changes.
- Watch for legacy page-level CSS overriding the shared navbar.
- If any page requires extra `<head>` assets, add a per-page slot in `header.php`.

## Scope
Public pages only (`Homescreen.php`, `Signup.php`, `/includes/*`). Login page can be migrated next.

## Follow-ups
- Remove any dead/duplicate CSS tied to old headers.
- Add basic smoke test for header anchors (optional).

Closes #4  
